### PR TITLE
PG-351: Added upgrade_20.sql file

### DIFF
--- a/sql/upgrade_20.sql
+++ b/sql/upgrade_20.sql
@@ -1,0 +1,1 @@
+ALTER TABLE  `civicrm_value_gift_aid_submission` CHANGE  `batch_name`  `batch_name` VARCHAR( 255 ) CHARACTER SET utf8 COLLATE utf8_unicode_ci NULL DEFAULT NULL


### PR DESCRIPTION
The reason why upgrade_20 is necessary is because of issue PG-274. upgrade_20.sql file adds sql query to alter 'batch_name' column from VARCHAR (256) to VARCHAR (255).