### PR TITLE
CGP-1081: Markup fix for Gitfaid form

### DIFF
--- a/templates/CRM/Civigiftaid/Form/Admin.tpl
+++ b/templates/CRM/Civigiftaid/Form/Admin.tpl
@@ -2,49 +2,60 @@
 {crmScript ext=uk.co.compucorp.civicrm.giftaid file=resources/js/script.js}
 
 <div id="gift-aid-settings" class="crm-block crm-form-block crm-export-form-block gift-aid settings">
-    <h3>Gift Aid Financial Types</h3>
+  <h3>Gift Aid Financial Types</h3>
+  <table class="form-layout-compressed">
+    <tbody>
+      <tr>
+        <td class="label">
+          <label>{$form.globally_enabled.label}</label>
+        </td>
+        <td>
+          {$form.globally_enabled.html}
+          <span class="help-text">Enable gift aid for line items of any financial type</span>
+        </td>
+      </tr>
+      <tr id="financial-types-container">
+        <td class="label">
+          <label>{$form.financial_types_enabled.label}</label>
+        </td>
+        <td>
+          {$form.financial_types_enabled.html}
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
-    <div class="crm-section">
-        <div class="label">{$form.globally_enabled.label}</div>
-        <div class="content">
-            {$form.globally_enabled.html}
-            <span class="help-text">Enable gift aid for line items of any financial type</span>
-        </div>
-        <div class="clear"></div>
-    </div>
+  {* FIELD EXAMPLE: OPTION 1 (AUTOMATIC LAYOUT)
+  <table>
+    <tbody>
+      {foreach from=$elementNames item=elementName}
+        <tr>
+          <td class="label">
+            <labek>{$form.$elementName.label}</label>
+          </td>
+          <td>
+            {$form.$elementName.html}
+          </td>
+        </tr>
+      {/foreach}
+    </tbody>
+  </table>
 
-    <div id="financial-types-container" class="crm-section">
-        <div class="label">{$form.financial_types_enabled.label}</div>
-        <div class="content">{$form.financial_types_enabled.html}</div>
-        <div class="clear"></div>
-    </div>
+  {* FIELD EXAMPLE: OPTION 2 (MANUAL LAYOUT)
+  <div>
+    <span>{$form.favorite_color.label}</span>
+    <span>{$form.favorite_color.html}</span>
+  </div>
 
-    {* FIELD EXAMPLE: OPTION 1 (AUTOMATIC LAYOUT)
+  {* FOOTER *}
 
-    {foreach from=$elementNames item=elementName}
-        <div class="crm-section">
-            <div class="label">{$form.$elementName.label}</div>
-            <div class="content">{$form.$elementName.html}</div>
-            <div class="clear"></div>
-        </div>
-    {/foreach}
-
-    {* FIELD EXAMPLE: OPTION 2 (MANUAL LAYOUT)
-
-      <div>
-        <span>{$form.favorite_color.label}</span>
-        <span>{$form.favorite_color.html}</span>
-      </div>
-
-    {* FOOTER *}
-
-    <div class="crm-submit-buttons">
-        {include file="CRM/common/formButtons.tpl" location="bottom"}
-    </div>
+  <div class="crm-submit-buttons">
+    {include file="CRM/common/formButtons.tpl" location="bottom"}
+  </div>
 </div>
 
 {literal}
-    <script type="text/javascript">
-        cj('#financial_types_enabled').crmSelect2();
-    </script>
+  <script type="text/javascript">
+    cj('#financial_types_enabled').crmSelect2();
+  </script>
 {/literal}


### PR DESCRIPTION
## Overview 
PR contains HTML fixes for Gift Aid CiviCRM ext form Markup fix to be similar as default CiviCRM markup.

### Before Fix
#### With Vanilla Civicrm
<img width="799" alt="giftaid form - initial vanila civi" src="https://user-images.githubusercontent.com/3340537/42690152-df9f5126-86c0-11e8-8b02-2d0fb1afaba7.png">

#### With Shoreditch Enabled
<img width="728" alt="giftaid form - initial - shoreditch" src="https://user-images.githubusercontent.com/3340537/42690169-ebce8688-86c0-11e8-92b4-2c9055c0dee1.png">

### After Fix

#### With default CiviCRM 
<img width="748" alt="giftaid form - final - vanilla civicrm" src="https://user-images.githubusercontent.com/3340537/42690208-0368e536-86c1-11e8-9d0f-460a03f65940.png">

#### With Shoreditch enabled
<img width="737" alt="gift aid form - final - shoreditch" src="https://user-images.githubusercontent.com/3340537/42690228-11f1ca64-86c1-11e8-9840-8681061a4f6b.png">


