### PR TITLE
Detect CiviCRM version >4 correctly

### DIFF
--- a/CRM/Civigiftaid/Utils/Hook.php
+++ b/CRM/Civigiftaid/Utils/Hook.php
@@ -109,7 +109,7 @@ abstract class CRM_Civigiftaid_Utils_Hook {
      */
     static function versionSwitcher($numParams, &$arg1, &$arg2, &$arg3, &$arg4, &$arg6, $fnSuffix, &$arg5 = NULL){
       $version = CRM_Utils_System::version();
-      preg_match('/4\.[0-9]\.[0-9]/', $version, $matches);
+      preg_match('/[0-9]\.[0-9]\.[0-9]/', $version, $matches);
       $versionNum = str_replace(".","",array_pop($matches));
       if ($versionNum >= 450){
         return self::singleton()->invoke($numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);


### PR DESCRIPTION
As per issue https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/issues/57 CiviCRM version 5 is not being detected correctly.

Tested on CiviCRM 5.4.0 in WordPress. No other tests done.