### PR TITLE
SPAB-839: Giftaid Not Working After Civi Upgrade

### DIFF
--- a/CRM/Civigiftaid/Utils/Hook.php
+++ b/CRM/Civigiftaid/Utils/Hook.php
@@ -109,7 +109,7 @@ abstract class CRM_Civigiftaid_Utils_Hook {
      */
     static function versionSwitcher($numParams, &$arg1, &$arg2, &$arg3, &$arg4, &$arg6, $fnSuffix, &$arg5 = NULL){
       $version = CRM_Utils_System::version();
-      preg_match('/4\.[0-9]\.[0-9]/', $version, $matches);
+      preg_match('/[0-9]\.[0-9]\.[0-9]/', $version, $matches);
       $versionNum = str_replace(".","",array_pop($matches));
       if ($versionNum >= 450){
         return self::singleton()->invoke($numParams, $arg1, $arg2, $arg3, $arg4, $arg5, $arg6, $fnSuffix);


### PR DESCRIPTION
The current Giftaid ext, to support olderversions of CiviCRM, has a version checking logic that only assumes the version to be 4.x.x. Because of this versions 5 and above are treated as old versions and this causes an error.
This PR fixes this issue.