### PR TITLE
MC-182: Fix SQL wrong order

### DIFF
--- a/CRM/Civigiftaid/Utils/GiftAid.php
+++ b/CRM/Civigiftaid/Utils/GiftAid.php
@@ -46,7 +46,7 @@ class CRM_Civigiftaid_Utils_GiftAid {
      * How long a positive Gift Aid declaration is valid for under HMRC rules (years).
      */
     const DECLARATION_LIFETIME = 3;
-    
+
     // Giftaid Declaration Options.
     const DECLARATION_IS_YES = 1;
     const DECLARATION_IS_NO = 0;
@@ -384,14 +384,14 @@ class CRM_Civigiftaid_Utils_GiftAid {
         // Update
         $sql = "
         UPDATE civicrm_value_gift_aid_submission
-        SET eligible_for_gift_aid = %1
-        WHERE entity_id = %2";
+        SET eligible_for_gift_aid = %2
+        WHERE entity_id = %1";
       }
 
       $queryParams = array(
         1 => array($params['entity_id'], 'Integer'),
         2 => array($params['eligible_for_gift_aid'], 'Integer'),
-      );  
+      );
       $dao = CRM_Core_DAO::executeQuery( $sql, $queryParams );
     }
 
@@ -470,7 +470,7 @@ class CRM_Civigiftaid_Utils_GiftAid {
       }
       return TRUE;
     }
-    
+
     /**
      * Get all gift aid declarations made by a contact.
      *
@@ -482,7 +482,7 @@ class CRM_Civigiftaid_Utils_GiftAid {
       $sql = "SELECT id, entity_id, eligible_for_gift_aid, start_date, end_date, reason_ended, source, notes
               FROM civicrm_value_gift_aid_declaration
               WHERE  entity_id = %1";
-      $sqlParams = array( 
+      $sqlParams = array(
                      1 => array($contactID, 'Integer')
                    );
 


### PR DESCRIPTION
### Overview ###

This PR is to fix bug for insert wrong value when update Giftaid submission. 
Ref. #82

### Before ###

When update contribution is updated, civicrm_value_gift_aid_submission will be updated and set eligible_for_gift_aid = Yes (1) or No (0)  and currently the table civicrm_value_gift_aid_submission will be updated incorrect or not  be updated  as the parameters are defined in incorrect order for example,  the value of entity ID will be inserted into eligible_for_gift_aid field will inserted of selected Eligible for Gift Aid field and SQL will search for entity_id of eligible_for_gift_aid field value.

  ```
    else {
        // Update
        $sql = "
        UPDATE civicrm_value_gift_aid_submission
        SET eligible_for_gift_aid = %1
        WHERE entity_id = %2";
      }

      $queryParams = array(
        1 => array($params['entity_id'], 'Integer'),
        2 => array($params['eligible_for_gift_aid'], 'Integer'),
      );  
      $dao = CRM_Core_DAO::executeQuery( $sql, $queryParams );
    }

```

### After ###

The correct parameters order is re-defined as per correct order.

```
      else {
        // Update
        $sql = "
        UPDATE civicrm_value_gift_aid_submission
        SET eligible_for_gift_aid = %2
        WHERE entity_id = %1";
      }

      $queryParams = array(
        1 => array($params['entity_id'], 'Integer'),
        2 => array($params['eligible_for_gift_aid'], 'Integer'),
      );
      $dao = CRM_Core_DAO::executeQuery( $sql, $queryParams );
```