### PR TITLE
RSE-276: Set Contribution as "Eligible for gift aid" automatically if a line item is eligible for gift aid

### DIFF
--- a/CRM/Civigiftaid/Form/Admin.php
+++ b/CRM/Civigiftaid/Form/Admin.php
@@ -53,9 +53,10 @@ class CRM_Civigiftaid_Form_Admin extends CRM_Core_Form {
   public function postProcess() {
     $values = $this->exportValues();
 
-    $settings = new stdClass();
-    $settings->globally_enabled = empty($values['globally_enabled']) ? 0 : 1;
-    $settings->financial_types_enabled = $values['financial_types_enabled'];
+    $settings = [
+      'globally_enabled' => empty($values['globally_enabled']) ? 0 : 1,
+      'financial_types_enabled' => $values['financial_types_enabled']
+    ];
 
     CRM_Core_BAO_Setting::setItem(
       $settings,
@@ -146,7 +147,7 @@ class CRM_Civigiftaid_Form_Admin extends CRM_Core_Form {
    * @throws \CiviCRM_API3_Exception
    */
   private function getFinancialTypes() {
-    $result = civicrm_api3('FinancialType', 'get', 
+    $result = civicrm_api3('FinancialType', 'get',
       array(
         'sequential' => 1,
         'is_active' => 1,

--- a/CRM/Civigiftaid/Hook/Post/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/Hook/Post/SetContributionGiftAidEligibility.php
@@ -1,0 +1,168 @@
+<?php
+
+use CRM_Civigiftaid_Utils_GiftAid as GiftAidUtil;
+
+/**
+ * Class CRM_Civigiftaid_Hook_Post_SetContributionGiftAidEligibility.
+ */
+class CRM_Civigiftaid_Hook_Post_SetContributionGiftAidEligibility {
+
+  /**
+   * Set the gift aid eligibility for a contribution.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   * @param mixed $objectId
+   *   Object ID.
+   * @param object $objectRef
+   *   Object reference.
+   */
+  public function run($op, $objectName, $objectId, &$objectRef) {
+    if (!$this->shouldRun($op, $objectName)) {
+      return;
+    }
+
+    $this->setGiftAidEligibilityStatus($objectId);
+  }
+
+  /**
+   * Sets gift aid eligibility status for a contribution.
+   *
+   * We are mainly concerned about contribution added from Events
+   * or the membership pages by the admin and not the Add new contribution screen as
+   * this screen already has a form widget to set gift aid eleigibility status.
+   *
+   * This function checks if the contribution is eligible and automatically sets
+   * the status to yes, else, it sets it to No.
+   *
+   * @param int $contributionId
+   *   Contribution Id.
+   */
+  private function setGiftAidEligibilityStatus($contributionId) {
+    $currentPath = CRM_Utils_System::currentPath();
+    $addMembershipPath = 'civicrm/member/add';
+    $registerEventParticipantPath = 'civicrm/participant/add';
+    if (!in_array($currentPath, [$registerEventParticipantPath, $addMembershipPath])) {
+      return;
+    }
+
+    $eligibilityFieldId = $this->getEligibilityFieldId();
+    $eligibilityField = 'custom_' . $eligibilityFieldId;
+
+    $contribution = civicrm_api3('Contribution', 'getsingle', [
+      'return' => ['financial_type_id', 'contact_id'],
+      'id' => $contributionId,
+    ]);
+
+    $allFinancialTypesEnabled = CRM_Civigiftaid_Form_Admin::isGloballyEnabled();
+    if ($allFinancialTypesEnabled || $this->financialTypeIsEligible($contribution['financial_type_id'])) {
+      $eligibility = GiftAidUtil::DECLARATION_IS_YES;
+    }
+    else {
+      $eligibility = GiftAidUtil::DECLARATION_IS_NO;
+    }
+
+    civicrm_api3('Contribution', 'create', [
+      $eligibilityField => $eligibility,
+      'id' => $contributionId,
+    ]);
+
+    $contributionContact = $contribution['contact_id'];
+    if (!GiftAidUtil::getDeclaration($contributionContact) && $eligibility == GiftAidUtil::DECLARATION_IS_YES) {
+      CRM_Core_Session::setStatus(ts($this->getMissingGiftAidDeclarationMessage($contributionContact)), 'Gift Aid Declaration', 'success');
+    }
+  }
+
+  /**
+   * Returns a warning message about missing gift aid declaration for
+   * contribution contact.
+   *
+   * @param int $contactId
+   *   Contact Id.
+   *
+   * @return string
+   *
+   */
+  private function getMissingGiftAidDeclarationMessage($contactId) {
+    $message = "This contribution has been automatically marked as Eligible for Gift Aid.
+      This is because the administrator has indicated that it's financial type is Eligible for Gift Aid.
+      However this contact does not have a valid Gift Aid Declaration. You can add one of these %s .";
+    $giftAidDeclarationGroupId = $this->getGiftAidDeclarationGroupId();
+    $selectedTab = 'custom_' . $giftAidDeclarationGroupId;
+    $link = "<a href='/civicrm/contact/view/?reset=1&gid={$giftAidDeclarationGroupId}&cid={$contactId}&selectedChild={$selectedTab}'> Here </a>";
+
+    return sprintf($message, $link);
+  }
+
+  /**
+   * Returns the gift aid declaration custom group Id.
+   *
+   * @return int
+   *   Custom group Id.
+   */
+  private function getGiftAidDeclarationGroupId() {
+    try {
+      $customGroup = civicrm_api3('CustomGroup', 'getsingle', [
+        'return' => ['id'],
+        'name' => 'Gift_Aid_Declaration',
+      ]);
+
+      return $customGroup['id'];
+    }
+    catch (Exception $e) {}
+  }
+
+  /**
+   * Checks if the contribution financial type is eligible for gift aid.
+   *
+   * @param mixed $financialType
+   *   Financial type.
+   *
+   * @return bool
+   *   Whether eligible or not.
+   */
+  private function financialTypeIsEligible($financialType) {
+    $eligibleFinancialTypes = CRM_Civigiftaid_Form_Admin::getFinancialTypesEnabled();
+
+    return in_array($financialType, $eligibleFinancialTypes);
+  }
+
+
+  /**
+   * Returns the eligibility custom field Id.
+   *
+   * @return int
+   *  Eligibility field Id.
+   */
+  private function getEligibilityFieldId() {
+    try {
+      $customField = civicrm_api3('CustomField', 'getsingle', [
+        'return' => ['id'],
+        'name' => 'eligible_for_gift_aid',
+        'custom_group_id' => 'Gift_Aid',
+      ]);
+
+      return $customField['id'];
+    }
+    catch (Exception $e) {}
+  }
+
+
+  /**
+   * Determines if the hook should run or not.
+   *
+   * @param string $op
+   *   The operation being performed.
+   * @param string $objectName
+   *   Object name.
+   *
+   * @return bool
+   *   returns a boolean to determine if hook will run or not.
+   */
+  private function shouldRun($op, $objectName) {
+    return $op == 'create' && $objectName == 'Contribution';
+  }
+
+}

--- a/CRM/Civigiftaid/Hook/Post/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/Hook/Post/SetContributionGiftAidEligibility.php
@@ -42,9 +42,7 @@ class CRM_Civigiftaid_Hook_Post_SetContributionGiftAidEligibility {
    */
   private function setGiftAidEligibilityStatus($contributionId) {
     $currentPath = CRM_Utils_System::currentPath();
-    $addMembershipPath = 'civicrm/member/add';
-    $registerEventParticipantPath = 'civicrm/participant/add';
-    if (!in_array($currentPath, [$registerEventParticipantPath, $addMembershipPath])) {
+    if (!in_array($currentPath, $this->getRequiredPaths())) {
       return;
     }
 
@@ -149,6 +147,21 @@ class CRM_Civigiftaid_Hook_Post_SetContributionGiftAidEligibility {
     catch (Exception $e) {}
   }
 
+
+  /**
+   * Returns paths/Urls where that needs this functionality implemented.
+   *
+   * @return array
+   *   Required paths.
+   */
+  private function getRequiredPaths() {
+    return [
+      'civicrm/member/add', // Add membership page
+      'civicrm/contact/view/membership', // Add membership from contact view page
+      'civicrm/participant/add', // Register event participant page
+      'civicrm/contact/view/participant' //Add participant from contact view page
+    ];
+  }
 
   /**
    * Determines if the hook should run or not.

--- a/civigiftaid.php
+++ b/civigiftaid.php
@@ -101,6 +101,19 @@ function civigiftaid_civicrm_searchTasks($objectType, &$tasks) {
 }
 
 /**
+ * Implementation of hook_civicrm_post.
+ */
+function civigiftaid_civicrm_post($op, $objectName, $objectId, &$objectRef) {
+  $hooks = [
+    new CRM_Civigiftaid_Hook_Post_SetContributionGiftAidEligibility(),
+  ];
+
+  foreach ($hooks as $hook) {
+    $hook->run($op, $objectName, $objectId, $objectRef);
+  }
+}
+
+/**
  * Implementation of hook_civicrm_postProcess
  * To copy the contact's home address to the declaration, when the declaration is created
  * Only for offline contribution


### PR DESCRIPTION
## Overview 
This PR allows the gift aid eligibility status for a contribution to be set automatically when a contribution is created by membership or events by the Administrator.

## Before
When a contribution is created by adding a membership or events registration by the administrator,  the gift aid eligibility status is not set automatically, the admin has to edit the created contribution manually to set the gift aid eligibility status.

## After
When a contribution is created by adding a membership or events registration by the administrator,  the gift aid eligibility status is set automatically. This functionality is only implemented for the related pages for when an admin is adding a membership or recording payment for an event participant.

For contacts without a valid declaration, after setting the eligibility status, a message is shown to the administrator with a link to add a valid gift aid declaration for such contacts.

## Technical Details
The `hook_civicrm_post` is implemented for the `Contribution` entity on create. If the financial type for the contribution is eligible for gift aid, the eligibility status of the contribution is set to Yes else it is set to No.

```php
    $allFinancialTypesEnabled = CRM_Civigiftaid_Form_Admin::isGloballyEnabled();
    if ($allFinancialTypesEnabled || $this->financialTypeIsEligible($contribution['financial_type_id'])) {
      $eligibility = GiftAidUtil::DECLARATION_IS_YES;
    }
    else {
      $eligibility = GiftAidUtil::DECLARATION_IS_NO;
    }

    civicrm_api3('Contribution', 'create', [
      $eligibilityField => $eligibility,
      'id' => $contributionId,
    ]);
```

## Comments
After fixing the issue reported in this PR, I discovered that the Gift Aid settings no longer works as it should on Civicrm version 5.19 which is the latest version for compu-deployed sites.
Investigations revealed that a new function  was intoduced `\CRM_Utils_String::unserialize` and used to [retrieve/deserialize](https://download.civicrm.org/latest/civicrm-RC-drupal.tar.gz) civicrm settings rather than the default php `unserialize` function.
The `\CRM_Utils_String::unserialize` function uses the https://github.com/xKerman/restricted-unserialize package which is not suitable for deserializing object instances.

The Gift aid settings were saved as object instance [here](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/master/CRM/Civigiftaid/Form/Admin.php#L56-L64), hence the fix was to change this to an array.