### PR TITLE
CPS-15: Update info XML file release date and compatibility (Release)

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,14 +18,12 @@
     <author>Erawat Chamanont, Jamie Novick, Guanhuan Chen, Robin Mitra</author>
     <email>jamie@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2019-08-12</releaseDate>
+  <releaseDate>2019-12-18</releaseDate>
   <version>3.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>
     <ver>4.7</ver>
-    <ver>5.0</ver>
-    <ver>5.19.4</ver>
   </compatibility>
   <comments>For support, please contact project team on the forums. (http://forum.civicrm.org) or create a new issue on https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/issues
   </comments>

--- a/info.xml
+++ b/info.xml
@@ -19,12 +19,13 @@
     <email>jamie@compucorp.co.uk</email>
   </maintainer>
   <releaseDate>2019-08-12</releaseDate>
-  <version>3.0.4</version>
+  <version>3.1.0</version>
   <develStage>stable</develStage>
   <compatibility>
     <ver>4.6</ver>
     <ver>4.7</ver>
     <ver>5.0</ver>
+    <ver>5.19.4</ver>
   </compatibility>
   <comments>For support, please contact project team on the forums. (http://forum.civicrm.org) or create a new issue on https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/issues
   </comments>


### PR DESCRIPTION
## Overview
There was an issue with Giftaid release v3.0.1 #91 as the compatibility tag in the info XML specifically targeted a [Civicrm version](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/master/info.xml#L28) which is not supported according to the doc [here](https://docs.civicrm.org/dev/en/latest/extensions/info-xml/#ver).

This PR fixes the issue by removing the version altogether and leaves the `<ver>4.7</ver>` to indicate forward compatibility with 5.x. as stated in the [doc](https://docs.civicrm.org/dev/en/latest/extensions/info-xml/#ver).

Release date is also updated.



