### PR TITLE
SPABSPRT-59: Prevent clash between giftaid and dd batches

### DIFF
--- a/CRM/Civigiftaid/Form/Task/AddToBatch.php
+++ b/CRM/Civigiftaid/Form/Task/AddToBatch.php
@@ -128,7 +128,7 @@ class CRM_Civigiftaid_Form_Task_AddToBatch extends CRM_Contribute_Form_Task {
     $batchParams['title'] = $params['title'];
     $batchParams['name'] = CRM_Utils_String::titleToVar($params['title'], 63);
     $batchParams['description'] = $params['description'];
-    $batchParams['batch_type'] = "Gift Aid";
+    $batchParams['type_id'] = CRM_Core_PseudoConstant::getKey('CRM_Batch_DAO_Batch', 'type_id', 'giftaid_batch');
 
     $session = CRM_Core_Session::singleton();
     $batchParams['created_id'] = $session->get('userID');

--- a/CRM/Civigiftaid/Upgrader.php
+++ b/CRM/Civigiftaid/Upgrader.php
@@ -66,6 +66,7 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
 
     $this->upgrade_3000();
     $this->upgrade_3101();
+    $this->upgrade_3103();
   }
 
   /**
@@ -338,6 +339,22 @@ class CRM_Civigiftaid_Upgrader extends CRM_Civigiftaid_Upgrader_Base {
 
     CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_field SET option_group_id = {$og1Id} WHERE name = 'Eligible_for_Gift_Aid' AND custom_group_id = {$declarationCustomGroupID}");
     CRM_Core_DAO::executeQuery("UPDATE civicrm_custom_field SET option_group_id = {$og2Id} WHERE name = 'Eligible_for_Gift_Aid' AND custom_group_id = {$submissionCustomGroupId}");
+
+    return TRUE;
+  }
+
+  /**
+   * Create Giftaid batch type.
+   */
+  public function upgrade_3103() {
+    $this->log('Applying update 3103');
+
+    $result = civicrm_api3('OptionValue', 'create', [
+        'option_group_id' => "batch_type",
+        'label' => 'Giftaid Batch',
+        'name' => 'giftaid_batch',
+        'description' => 'Giftaid Batch Type',
+    ]);
 
     return TRUE;
   }


### PR DESCRIPTION
## Overview
Contributions cannot be added to a GA batch because they are already in a direct debit batch and the system doesn't allow them to be in both. 
The solution to this problem is to adjust the batching logics in both GiftAid and Direct Debit extensions to be batch type specific. We are implementing mentioned solution as part of this PR.

## Before
There was no batch type for Gift aid batches. As a result, if the contribution is present in batches table, GA logic assumed that its already been added to batch.

## After
Gift Aid batch type has been introduced and now the same contribution can be added to both DD and GA batches.

## Technical Details
1. Introduced a batch type `giftaid_batch` using upgrader and installer.
2. While fetching contributions, now the query checks the batch type as well. This prevents GA from thinking that the contribution is already in GA batch if it's in the batch table.
