### PR TITLE
MAE-385: Bump version to 3.2.0

### DIFF
--- a/info.xml
+++ b/info.xml
@@ -18,12 +18,11 @@
     <author>Erawat Chamanont, Jamie Novick, Guanhuan Chen, Robin Mitra</author>
     <email>jamie@compucorp.co.uk</email>
   </maintainer>
-  <releaseDate>2019-12-18</releaseDate>
-  <version>3.1.0</version>
+  <releaseDate>2020-10-07</releaseDate>
+  <version>3.2.0</version>
   <develStage>stable</develStage>
   <compatibility>
-    <ver>4.6</ver>
-    <ver>4.7</ver>
+    <ver>5.28</ver>
   </compatibility>
   <comments>For support, please contact project team on the forums. (http://forum.civicrm.org) or create a new issue on https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/issues
   </comments>


### PR DESCRIPTION
### Overview

This PR is to bump version 3.2.0 for ME v3 release.

