### PR TITLE
CPS-527: Fix issue with NULL schema version upon install

### DIFF
--- a/civigiftaid.php
+++ b/civigiftaid.php
@@ -38,6 +38,15 @@ function civigiftaid_civicrm_install() {
 }
 
 /**
+ * Implements hook_civicrm_postInstall().
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_postInstall
+ */
+function civigiftaid_civicrm_postInstall() {
+  _civigiftaid_civix_civicrm_postInstall();
+}
+
+/**
  * Implementation of hook_civicrm_uninstall
  */
 function civigiftaid_civicrm_uninstall() {


### PR DESCRIPTION
## Overview
When the Giftaid extension is installed on a fresh site, the schema version for the extension is NULL in the `civicrm_extension` table even though the extension has upgraders and the schema version is supposed to be set to the latest upgrader number, in this case it should have been `3103`. This causes an issue on the extensions page, where a notice is shown that there are pending updates for giftaid extension.

## Before 
The issue describe above exists

## After
We recently updated the civicrm base upgrader and civix classes in this PR: https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/pull/100. Initially, before the upgrade, the function responsible for setting the current revision for the extension was invoked on the onInstall, see: https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/commit/c2349c1aae5d104fd23f3017e4fae802da2813e1#diff-17a769595793cd1b5bbe7f54fdb71a32c49d49af6726760db1d3995f660d5912R258, but with the changes, the function is now called on the `onPostInstall` function: https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/master/CRM/Civigiftaid/Upgrader/Base.php#L336, because the Giftaid function does not implement this hook in the `giftaid.php` file, the `onPostInstall` is never triggered and the current revision is never set, hence the reason why it is NULL.

The issue is fixed by implementing the postInstall hook in the extension.