### PR TITLE
CIVIPLUS-782: Prevent adding a contribution to a gift_aid batch multiple times

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+## Overview
+_A brief description of the pull request. Try to keep it non-technical._
+
+## Before
+_The current status. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## After
+_What has been changed. Please provide screenshots or gifs ([LICEcap](http://www.cockos.com/licecap/), [SilentCast](https://github.com/colinkeenan/silentcast)) where appropriate._
+
+## Technical Details
+_If the PR introduces noteworthy technical changes, please describe them here. Provide code snippets if necessary_
+
+### Core overrides
+_If the PR overrides/patches a core file, then please explain here, for each file:_
+
+1. _Which file it is_
+2. _The reason why it was overridden/patched_
+3. _What the override/patch consists of_
+
+## Comments
+_Anything else you would like the reviewer to note_

--- a/CRM/Civigiftaid/Utils/Contribution.php
+++ b/CRM/Civigiftaid/Utils/Contribution.php
@@ -620,14 +620,14 @@ class CRM_Civigiftaid_Utils_Contribution {
    * @param array $contributionIDs
    *  Array of contribution Ids.
    * @return array
-   *  Array of contributions Ids that are alredy in batch.
+   *  Array of contributions Ids that are already in batch.
    */
   private static function getContributionsInBatch(array $contributionIDs) {
     $contributions = civicrm_api3('EntityBatch', 'get', [
         'return' => ['entity_id'],
         'entity_table' => 'civicrm_contribution',
         'batch_id.type_id' => "giftaid_batch",
-        'entity_id' => [ 'IN' => [$contributionIDs]],
+        'entity_id' => [ 'IN' => (array) $contributionIDs],
     ]);
 
     $contributionsInBatch = [];


### PR DESCRIPTION
## Overview
This PR resolves the issue with contributions already in a Gift Aid batch showing up again on a new Gift Aid batch and marked as eligible.

## Before
Contributions can be added to the gift aid batch multiple times.
![CIVIPLUS-782](https://user-images.githubusercontent.com/85277674/170239905-2d322816-e0d0-4b5c-a3bf-9b55bc2c6fa4.gif)

## After
Contributions can be added to the gift aid batch once.
![giftaid](https://user-images.githubusercontent.com/85277674/170240201-ba82717f-a950-4f25-b48a-e895d680f7c0.gif)

