### PR TITLE
CIVIPLUS-783: Delete declaration with no start_date before inserting new declaration

### DIFF
--- a/CRM/Civigiftaid/Utils/GiftAid.php
+++ b/CRM/Civigiftaid/Utils/GiftAid.php
@@ -215,9 +215,11 @@ class CRM_Civigiftaid_Utils_GiftAid {
         if ( $params['eligible_for_gift_aid'] == 1 ) {
 
             if ( !$currentDeclaration ) {
-                // There is no current declaration so create new.
-               CRM_Civigiftaid_Utils_GiftAid::_insertDeclaration( $params, $endTimestamp );
-
+              // There are cases when CiviCRM creates a new decalaration with null start_date
+              // before the appropriate hook that uses this function is called, if that happens
+              // we delete such decalaration before creating a new one.
+              CRM_Civigiftaid_Utils_GiftAid::_deleteDecarationWithNullStartDate($params['entity_id']);
+              CRM_Civigiftaid_Utils_GiftAid::_insertDeclaration( $params, $endTimestamp );
             } else if ( $currentDeclaration['eligible_for_gift_aid'] == 1 && $endTimestamp ) {
                 //   - if current positive, extend its end_date to new_end_date.
                 $updateParams = array(
@@ -343,8 +345,21 @@ class CRM_Civigiftaid_Utils_GiftAid {
         $dao = CRM_Core_DAO::executeQuery( $sql, $queryParams );
     }
 
+    /**
+     * Deletes a contact declaration with null start date.
+     * 
+     * @param int $id
+     *  ID of the Contact for whom we're deleting decalaration.
+     */
+    static function _deleteDecarationWithNullStartDate($contactID) {
+      CRM_Utils_SQL_Delete::from('civicrm_value_gift_aid_declaration')
+        ->where('entity_id = #contact', ['contact' => $contactID])
+        ->where('start_date IS NULL')
+        ->execute();
+    }
+
     static function getContactsWithDeclarations() {
-      $contactsWithPastDeclarations = array();
+      $contactsWithDeclarations = [];
       $sql = "
         SELECT id, eligible_for_gift_aid, entity_id
         FROM   civicrm_value_gift_aid_declaration


### PR DESCRIPTION
## Overview
This PR fixes the issue with two declarations being created when a user submits a contribution using a webform or CiviCRM contribution page. 
This bug happens because when a user submits the form and they check the `UK Tax Payer` custom field, CiviCRM automatically creates a declaration(i.e. fills a new `Gift Aid Declaration`  custom group for the user), but also there are [hooks in the extension](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/7fb227435aa4e8a6244eb6fce54f6ac23fe2ffa6/civigiftaid.php#L190) and in [`giftaid_webform_integration`](https://github.com/compucorp/giftaid_webform_integration/blob/c1293cd6a8fed87f98420cef19ddb4044617a52e/giftaid_webform_integration.module#L26) that are actually meant to create a declaration with the appropriate formatted values.
<img width="873" alt="Screenshot 2022-05-25 at 16 48 18" src="https://user-images.githubusercontent.com/85277674/170304037-d6a3dd99-865d-4aea-9bcf-fbd98c2ab37a.png">


## Before
Two declarations are created.
<img width="1183" alt="Screenshot 2022-05-25 at 17 09 07" src="https://user-images.githubusercontent.com/85277674/170308154-0456a592-1987-4d54-bb34-cca183bc5572.png">

## After
The invalid declarration is deleted, before creating a new declaration.
<img width="717" alt="Screenshot 2022-05-25 at 17 10 03" src="https://user-images.githubusercontent.com/85277674/170308235-64c19d30-9210-40ff-9eaa-944656613ab9.png">

