### PR TITLE
MAE-982: Fix Add Batch screen error on PHP8

### DIFF
--- a/CRM/Civigiftaid/Utils/Contribution.php
+++ b/CRM/Civigiftaid/Utils/Contribution.php
@@ -458,6 +458,10 @@ class CRM_Civigiftaid_Utils_Contribution {
     self::addContributionDetails($contributionIdStr, $result);
 
     if (count($result)) {
+      array_walk($result, function(&$contribution) {
+        $contribution['line_items'] = [];
+      });
+
       self::addLineItemDetails($contributionIdStr, $result);
     }
 


### PR DESCRIPTION
## Overview
On PHP8 when a contribution doesn't have a line item or all the line items' financial types are not enabled for GiftAid, the page is broken with the error message `The website encountered an unexpected error. Please try again later.`

## Before
<img width="1216" alt="Screenshot 2022-12-19 at 09 52 09" src="https://user-images.githubusercontent.com/85277674/208385747-4fc79829-e0f0-4f20-b477-152a31efa352.png">


## After
<img width="1161" alt="Screenshot 2022-12-19 at 09 51 32" src="https://user-images.githubusercontent.com/85277674/208385627-0b6b5db0-4c72-4daa-9987-56d71c54e855.png">

## Technical Details
This error happens because an attempt is made to count a NULL value in the lines mentioned below, which is not allowed in [PHP 8](https://www.php.net/manual/en/function.count).

https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/5267c6105af6be8e9176d42f2df48fae6a177716/templates/CRM/Civigiftaid/Form/Task/AddToBatch.tpl#L82
https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/5267c6105af6be8e9176d42f2df48fae6a177716/templates/CRM/Civigiftaid/Form/Task/AddToBatch.tpl#L128
https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/blob/5267c6105af6be8e9176d42f2df48fae6a177716/templates/CRM/Civigiftaid/Form/Task/AddToBatch.tpl#L174

Instead of adding multiple if/else in the template file, the default line_items is set to an empty array instead of NULL.
