### PR TITLE
CIVIPLUS-783: Delete declaration with no start_date before inserting new declaration

### DIFF
--- a/CRM/Civigiftaid/Declaration.php
+++ b/CRM/Civigiftaid/Declaration.php
@@ -285,6 +285,20 @@ class CRM_Civigiftaid_Declaration {
   }
 
   /**
+   * Deletes a contact declaration with null start date.
+   *
+   * @param array $params
+   *    Declaration params.
+   */
+  public static function deleteDeclarationWithNullStartDate(&$params) {
+    CRM_Utils_SQL_Delete::from('civicrm_value_gift_aid_declaration')
+      ->where('entity_id = #contact', ['contact' => $params['entity_id']])
+      ->where('start_date IS NULL')
+      ->execute();
+    unset($params['id']);
+  }
+
+  /**
    * Delete all declarations that are missing a postcode and a start_date for
    * the given contact.
    *
@@ -367,6 +381,12 @@ class CRM_Civigiftaid_Declaration {
         $endTimestamp = strtotime($futureDeclaration['start_date']);
       }
     }
+
+    // There are cases when CiviCRM creates a new declaration with null
+    // start_date before the appropriate hook that uses this function is
+    // called, if that happens we delete such declaration before creating
+    // a new one.
+    CRM_Civigiftaid_Declaration::deleteDeclarationWithNullStartDate($newParams);
 
     // Order of preference: PAST_4_YEARS > YES > YES
     switch ($newParams['eligible_for_gift_aid']) {


### PR DESCRIPTION
## Overview

This PR addresses the issue with Gift Aid declaration details not updating correctly. The fix has been backported from this patch PR: https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/pull/112, and it has been adjusted to align with the updates made to the community version.