### PR TITLE
CIVIPLMMSR-180: Reevaluate contribution giftaid amount after creating lineitem

### DIFF
--- a/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
@@ -25,11 +25,25 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility {
    * @throws \CiviCRM_API3_Exception
    */
   public static function runCallback($event) {
-    if (($event->entity !== 'Contribution') || !in_array($event->action, ['create', 'edit'])) {
+    if ((!in_array($event->entity, ['Contribution', 'LineItem'])) || !in_array($event->action, ['create', 'edit'])) {
       return;
     }
 
-    if (self::setGiftAidEligibilityStatus($event->id, $event->action)) {
+    $id = $event->id;
+    if ($event->entity == 'LineItem') {
+      $lineItem = \Civi\Api4\LineItem::get(FALSE)
+      ->addWhere('id', '=', $id)
+      ->execute()
+      ->first();
+      
+      $id = $lineItem['contribution_id'] ?? NULL;
+    }
+
+    if (empty($id)) {
+      return;
+    }
+
+    if (self::setGiftAidEligibilityStatus($id, $event->action)) {
       $event->object->find();
       if (!CRM_Civigiftaid_Declaration::getDeclaration($event->object->contact_id)) {
         if (CRM_Core_Session::getLoggedInContactID() && CRM_Core_Permission::check('access CiviContribute')) {


### PR DESCRIPTION
## Overview
In CiviCRM, there are instances where LineItems are created before Contributions, while in other cases, Contributions are created before LineItems. This extension assumes the former scenario but occasionally results in Contributions eligible for Gift Aid with empty Gift Aid amounts because the LineItems are not yet created.

This PR addresses the issue by reevaluating the Gift Aid amount for Contributions after LineItems are created.

## Before
![98a73e7e-08c5-4d19-81b3-935de6c2d91e](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/assets/85277674/b2353aed-8261-4bd9-ab45-2372d2518963)

## After
![qw12121212121](https://github.com/compucorp/uk.co.compucorp.civicrm.giftaid/assets/85277674/b1b28081-3e6a-45d2-93ce-01a2e12bc490)
