### PR TITLE
CUB-56: Allow changes to be made to the batched contributions via hook

### DIFF
--- a/CRM/Civigiftaid/Utils/Hook.php
+++ b/CRM/Civigiftaid/Utils/Hook.php
@@ -41,7 +41,7 @@ abstract class CRM_Civigiftaid_Utils_Hook extends CRM_Utils_Hook {
    *
    * @return mixed
    */
-  public static function batchContributions($batchID, $contributionsAdded) {
+  public static function batchContributions($batchID, &$contributionsAdded) {
     return self::singleton()->invoke(['batchID', 'contributionsAdded'], $batchID, $contributionsAdded, self::$_nullObject, self::$_nullObject, self::$_nullObject, self::$_nullObject, 'civicrm_batchContributions');
   }
 


### PR DESCRIPTION
## Overview
The extension allows actions to be performed on the to-be-batched GiftAid Contributions, but it doesn't allow contributions to be added or removed from the list. 

In this PR we now pass the to-be-batched contribution IDs as a reference allowing extensions to manipulate this list via the hook.