### PR TITLE
CIVIPLMMSR-350: Fix Batch Detail Report

### DIFF
--- a/CRM/Civigiftaid/Upgrader.php
+++ b/CRM/Civigiftaid/Upgrader.php
@@ -432,7 +432,7 @@ class CRM_Civigiftaid_Upgrader extends CRM_Extension_Upgrader_Base {
 
   private function ensureReportInstanceExist() {
     $ogId = $this->getReportTemplateGroupId();
-    
+
     return CRM_Core_BAO_OptionValue::ensureOptionValueExists([
       'option_group_id' => $ogId,
       'label' => 'Gift Aid Report',
@@ -455,10 +455,9 @@ class CRM_Civigiftaid_Upgrader extends CRM_Extension_Upgrader_Base {
     catch (Exception $e) {
       $reportID = NULL;
     }
-
+    $reportTemplate = $this->ensureReportInstanceExist();
     if (!$reportID) {
       try {
-        $reportTemplate = $this->ensureReportInstanceExist();
         civicrm_api3('ReportInstance', 'create', [
           'title' => $reportTemplate['label'],
           'report_id' => $reportTemplate['value'],
@@ -747,6 +746,13 @@ class CRM_Civigiftaid_Upgrader extends CRM_Extension_Upgrader_Base {
         ->execute();
     }
 
+    return TRUE;
+  }
+
+  public function upgrade_3119() {
+    $this->log('Check and create GiftAid report instance');
+    $this->removeLegacyRegisteredReport();
+    $this->createReportInstance();
     return TRUE;
   }
 


### PR DESCRIPTION
## Overview
This pr fixes an issue that restricted user from accessing the batch detail report.

## Before
User was presented with a following warning message and was redirected to report list page when he tried to access the batch detail report
<img width="297" alt="Screenshot 2024-10-16 at 17 14 49" src="https://github.com/user-attachments/assets/ec6fe6ce-7d59-4ab3-a29a-d200838c1452" />

## After
User is able to access the report
<img width="1792" alt="Screenshot 2025-02-18 at 12 09 29 PM" src="https://github.com/user-attachments/assets/b4a645c5-094d-4d2f-8ff9-decac815f7f7" />

