### PR TITLE
CIVIMM-386: Remove default value from contribution Gift Aid eligibility field and prevent duplicate status messages

### DIFF
--- a/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
@@ -48,7 +48,12 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility {
       if (!CRM_Civigiftaid_Declaration::getDeclaration($event->object->contact_id)) {
         if (CRM_Core_Session::getLoggedInContactID() && CRM_Core_Permission::check('access CiviContribute')) {
           // Only show message if we have a logged in contact with permissions to access CiviContribute
-          CRM_Core_Session::setStatus(self::getMissingGiftAidDeclarationMessage($event->object->contact_id), E::ts('Gift Aid Declaration'), 'info');
+          // Use static variable to prevent showing the same message multiple times per page load
+          $messageKey = 'giftaid_declaration_status_' . $id;
+          if (!isset(Civi::$statics[__CLASS__][$messageKey])) {
+            CRM_Core_Session::setStatus(self::getMissingGiftAidDeclarationMessage($event->object->contact_id), E::ts('Gift Aid Declaration'), 'info');
+            Civi::$statics[__CLASS__][$messageKey] = TRUE;
+          }
         }
       }
     }

--- a/CRM/Civigiftaid/Upgrader.php
+++ b/CRM/Civigiftaid/Upgrader.php
@@ -756,6 +756,23 @@ class CRM_Civigiftaid_Upgrader extends CRM_Extension_Upgrader_Base {
     return TRUE;
   }
 
+  public function upgrade_3120() {
+    $this->log('Fix default value for contribution eligible_for_gift_aid custom field');
+    try {
+      $results = \Civi\Api4\CustomField::update(FALSE)
+        ->addValue('default_value', NULL)
+        ->addValue('is_required', FALSE)
+        ->addWhere('name', '=', 'eligible_for_gift_aid')
+        ->execute();
+      
+      $this->log('Successfully updated default_value for eligible_for_gift_aid field. Updated ' . count($results) . ' field(s)');
+    }
+    catch (Exception $e) {
+      $this->log('Failed to update default_value for eligible_for_gift_aid field: ' . $e->getMessage());
+    }
+    return TRUE;
+  }
+
   /**
    * Add the specified option group, gracefully if it already exists.
    *
@@ -988,6 +1005,7 @@ class CRM_Civigiftaid_Upgrader extends CRM_Extension_Upgrader_Base {
         'label' => 'Eligible for Gift Aid?',
         'data_type' => 'Int',
         'html_type' => 'Radio',
+        'default_value' => NULL,
         'is_required' => '0',
         'is_searchable' => '1',
         'is_search_range' => '0',


### PR DESCRIPTION
## Overview
Fixed two issues with the Gift Aid contribution form: the "Eligible for Gift Aid?" field was incorrectly defaulting to "Yes" even when no financial types were configured as eligible, and users were receiving duplicate status messages about missing Gift Aid declarations.

## Before
- When creating a new contribution, the "Eligible for Gift Aid?" field would automatically be set to "Yes" by default
- This happened even when no financial types were configured as eligible for Gift Aid
- Users would see multiple duplicate status messages saying "Gift Aid Declaration missing" when processing contributions
- The form behavior was confusing and led to incorrect Gift Aid eligibility being set

## After
- The "Eligible for Gift Aid?" field now starts unselected/blank by default
- Only shows as eligible when financial types are properly configured or manually selected
- Status messages about missing Gift Aid declarations only appear once per contact per page load
- Form behavior is now consistent with the extension's configuration

![qaweewewewe](https://github.com/user-attachments/assets/3ca27e5f-bc10-4bca-9ec9-2a80d292204e)

## Technical Details

### 1. Fixed Default Value Issue
**Root Cause**: The custom field `eligible_for_gift_aid` didn't have an explicit `default_value` set to `NULL`, causing CiviCRM to potentially auto-select the first option.

**Solution**: 
- Updated the custom field definition in `CRM_Civigiftaid_Upgrader.php` to explicitly set `'default_value' => NULL`
- Added upgrader function `upgrade_3120()` to fix existing installations:

```php
$results = \Civi\Api4\CustomField::update(FALSE)
  ->addValue('default_value', NULL)
  ->addValue('is_required', FALSE)
  ->addWhere('name', '=', 'eligible_for_gift_aid')
  ->execute();
```

### 2. Prevented Duplicate Status Messages
**Root Cause**: The `runCallback` method in `CRM_Civigiftaid_SetContributionGiftAidEligibility` was called multiple times per page load, showing duplicate "Gift Aid Declaration missing" messages.

**Solution**: Added static variable tracking to prevent duplicate messages:

```php
$messageKey = 'giftaid_declaration_status_' . $id;
if (!isset(Civi::$statics[__CLASS__][$messageKey])) {
  CRM_Core_Session::setStatus(self::getMissingGiftAidDeclarationMessage($event->object->contact_id), E::ts('Gift Aid Declaration'), 'info');
  Civi::$statics[__CLASS__][$messageKey] = TRUE;
}
```
