### PR TITLE
COMCL-1373: Fix financial type giftaid eligibility

### DIFF
--- a/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
@@ -35,7 +35,7 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility extends AutoSubscriber {
     if ((!in_array($event->entity, ['Contribution', 'LineItem'])) || !in_array($event->action, ['create', 'edit'])) {
       return;
     }
-    
+
     $id = $event->id;
     if ($event->entity == 'LineItem') {
       $lineItem = \Civi\Api4\LineItem::get(FALSE)
@@ -217,7 +217,16 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility extends AutoSubscriber {
    */
   private static function financialTypeIsEligible(int $financialType): bool {
     $eligibleFinancialTypes = \Civi::settings()->get('civigiftaid_financial_types_enabled');
-    return in_array($financialType, $eligibleFinancialTypes);
+    if (!in_array($financialType, $eligibleFinancialTypes)) {
+      return FALSE;
+    }
+
+    return (bool) \Civi\Api4\FinancialType::get(FALSE)
+      ->selectRowCount()
+      ->addWhere('id', '=', $financialType)
+      ->addWhere('is_active', '=', TRUE)
+      ->execute()
+      ->count();
   }
 
 }


### PR DESCRIPTION
## Overview
Currently for checking if a financial type is eligible for giftaid or not we only check if its included in giftaid settings, but if a financial type is included in settings and then disabled we still mark the contributions for that financial type as eligible for giftaid. This PR fixes the issue by adding a check for the financial type status before marking any contribution eligible for giftaid.
