### PR TITLE
COMCL-1372: Fix setting of eligibility on contributions

### DIFF
--- a/CRM/Civigiftaid/Utils/Contribution.php
+++ b/CRM/Civigiftaid/Utils/Contribution.php
@@ -132,7 +132,13 @@ class CRM_Civigiftaid_Utils_Contribution {
           ->first()['total_amount'];
         $giftAidableContribAmt = self::getGiftAidableContribAmt($totalAmount, $contributionID);
         $giftAidAmount = self::calculateGiftAidAmt($giftAidableContribAmt, self::getBasicRateTax());
-        if ((bccomp($giftAidAmount, 0.0, 1) === 0) && (bccomp($giftAidableContribAmt, 0.0, 1) === 0)) {
+        $lineItemCount = \Civi\Api4\LineItem::get(FALSE)
+          ->selectRowCount()
+          ->addWhere('contribution_id', '=', $contributionID)
+          ->execute()
+          ->count();
+        if ((bccomp($giftAidAmount, 0.0, 1) === 0) && (bccomp($giftAidableContribAmt, 0.0, 1) === 0)
+          && $lineItemCount > 0) {
           // If we don't have an enabled financialType contribution is not eligible
           $eligibleForGiftAid = 0;
         }

--- a/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
+++ b/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
@@ -402,6 +402,114 @@ class CRM_Civigiftaid_Utils_ContributionTest extends \PHPUnit\Framework\TestCase
       ->execute();
   }
 
+  public function testEligibleContributionWithoutLineItemsRemainsEligibleUntilLineItemsExist() {
+    $this->setupFixture1();
+
+    $contributionID = Contribution::create(FALSE)
+                        ->addValue('contact_id', $this->contacts[0]['id'])
+                        ->addValue('financial_type_id', 1)
+                        ->addValue('total_amount', 100)
+                        ->execute()
+                        ->first()['id'];
+
+    // Simulate workflows (e.g. webform) where contribution exists before line items are attached.
+    \Civi\Api4\LineItem::delete(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->execute();
+
+    CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields($contributionID, 1, '');
+    $contribution = $this->fetchContributionGiftAid($contributionID);
+
+    $this->assertEquals(1, $contribution['gift_aid.eligible_for_gift_aid']);
+    $this->assertEquals(0, (float) $contribution['gift_aid.amount']);
+    $this->assertEquals(0, (float) $contribution['gift_aid.gift_aid_amount']);
+  }
+
+  public function testEligibleContributionWithEligibleLineItemsCalculatesExpectedAmounts() {
+    $this->setupFixture1();
+
+    $contributionID = civicrm_api3('Order', 'create', [
+      'contact_id' => $this->contacts[0]['id'],
+      'financial_type_id' => 1,
+      'total_amount' => 100,
+      'line_items' => [[
+        'line_item' => [[
+          'line_total' => 100,
+          'financial_type_id' => 1,
+          'price_field_id' => 1,
+          'qty' => 1,
+        ]],
+      ]],
+    ])['id'];
+
+    CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields($contributionID, 1, '');
+    $contribution = $this->fetchContributionGiftAid($contributionID);
+
+    $this->assertEquals(1, $contribution['gift_aid.eligible_for_gift_aid']);
+    $this->assertEquals(100, (float) $contribution['gift_aid.amount']);
+    $this->assertEquals(25, (float) $contribution['gift_aid.gift_aid_amount']);
+  }
+
+  public function testEligibleContributionWithOnlyIneligibleLineItemsBecomesIneligible() {
+    $this->setupFixture1();
+
+    $contributionID = civicrm_api3('Order', 'create', [
+      'contact_id' => $this->contacts[0]['id'],
+      'financial_type_id' => 4,
+      'total_amount' => 100,
+      'line_items' => [[
+        'line_item' => [[
+          'line_total' => 100,
+          'financial_type_id' => 4,
+          'price_field_id' => 1,
+          'qty' => 1,
+        ]],
+      ]],
+    ])['id'];
+
+    CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields($contributionID, 1, '');
+    $contribution = $this->fetchContributionGiftAid($contributionID);
+
+    $this->assertEquals(0, $contribution['gift_aid.eligible_for_gift_aid']);
+    $this->assertEquals(0, (float) $contribution['gift_aid.amount']);
+    $this->assertEquals(0, (float) $contribution['gift_aid.gift_aid_amount']);
+  }
+
+  public function testWebformLikeFlowRecalculatesEligibilityWhenLineItemsAddedLater() {
+    $this->setupFixture1();
+
+    $contribution = Contribution::create(FALSE)
+      ->addValue('contact_id', $this->contacts[0]['id'])
+      ->addValue('financial_type_id', 1)
+      ->addValue('total_amount', 100)
+      ->execute()
+      ->first();
+    $contributionID = $contribution['id'];
+
+    // Start with no line items - first calculation should keep eligible=1 and zero amounts.
+    \Civi\Api4\LineItem::delete(FALSE)
+      ->addWhere('contribution_id', '=', $contributionID)
+      ->execute();
+    CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields($contributionID, 1, '');
+
+    // Add line item afterwards, then recalculate to reflect final state.
+    civicrm_api3('LineItem', 'create', [
+      'entity_table' => 'civicrm_contribution',
+      'entity_id' => $contributionID,
+      'contribution_id' => $contributionID,
+      'line_total' => 100,
+      'unit_price' => 100,
+      'qty' => 1,
+      'financial_type_id' => 1,
+    ]);
+    CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields($contributionID, 1, '');
+
+    $updated = $this->fetchContributionGiftAid($contributionID);
+    $this->assertEquals(1, $updated['gift_aid.eligible_for_gift_aid']);
+    $this->assertEquals(100, (float) $updated['gift_aid.amount']);
+    $this->assertEquals(25, (float) $updated['gift_aid.gift_aid_amount']);
+  }
+
   /**
    * Data provider for testIsContributionEligible
    *


### PR DESCRIPTION
## Overview
This PR fixes an issue which wrongly disabled the giftaid eligibility on contributions which should have giftaid eligibility.

## Technical Details
A scenario in which contribution record is created fist before the creation of line items like webform submission will mark the eligibility as 0 [here](https://lab.civicrm.org/extensions/ukgiftaid/-/blob/master/CRM/Civigiftaid/Utils/Contribution.php?ref_type=heads#L137) because the giftaid amount is calculated based on eligible line items and there are no line items created yet for this contribution and then later on in the same request when the line items gets created [this](https://lab.civicrm.org/extensions/ukgiftaid/-/blob/master/CRM/Civigiftaid/SetContributionGiftAidEligibility.php?ref_type=heads#L101) check does not lets recalculate the eligibility for this contribution.

This PR changes the logic to only set the eligibility as 0 if there are line items and still the amounts are 0