### PR TITLE
COMCL-1371: Fix Contact Link On Batch Screen

### DIFF
--- a/templates/CRM/Civigiftaid/Form/Task/AddToBatch.tpl
+++ b/templates/CRM/Civigiftaid/Form/Task/AddToBatch.tpl
@@ -63,7 +63,7 @@
           {foreach from=$contributionsAddedRows item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount|crmMoney:$row.currency}</td>
               <td>{$row.total_amount|crmMoney:$row.currency}</td>
@@ -106,7 +106,7 @@
           {foreach from=$contributionsAlreadyAddedRows item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount|crmMoney:$row.currency}</td>
               <td>{$row.total_amount|crmMoney:$row.currency}</td>
@@ -149,7 +149,7 @@
           {foreach from=$contributionsNotValid item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount|crmMoney:$row.currency}</td>
               <td>{$row.total_amount|crmMoney:$row.currency}</td>

--- a/templates/CRM/Civigiftaid/Form/Task/RemoveFromBatch.tpl
+++ b/templates/CRM/Civigiftaid/Form/Task/RemoveFromBatch.tpl
@@ -37,7 +37,7 @@
           {foreach from=$contributionsToRemoveRows item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount}</td>
               <td>{$row.total_amount}</td>
@@ -81,7 +81,7 @@
           {foreach from=$contributionsAlreadySubmitedRows item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount}</td>
               <td>{$row.total_amount}</td>
@@ -125,7 +125,7 @@
           {foreach from=$contributionsNotInBatchRows item=row}
             <tr class="contribution" data-contribution-id="{$row.contribution_id}">
               <td>
-                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=$row.contact_id"}">{$row.display_name}</a>
+                <a href="{crmURL p='civicrm/contact/view' q="reset=1&cid=`$row.contact_id`"}">{$row.display_name}</a>
               </td>
               <td>{$row.gift_aidable_amount}</td>
               <td>{$row.total_amount}</td>


### PR DESCRIPTION
## Overview
This PR fixes the contact link on add/remove contributions from a batch screen

## Technical Details
Currently the link was being fromed with cid=`Array.contact_id` this was due to incompatibility between how the link was being formed and smarty version as on old smarty version this link formation code was working fine. This Pr fixes this code to work with new smarty version as well.
