### PR TITLE
COMCL-1408: Fix setting of eligibility on contributions

### DIFF
--- a/CRM/Civigiftaid/Utils/Contribution.php
+++ b/CRM/Civigiftaid/Utils/Contribution.php
@@ -132,15 +132,9 @@ class CRM_Civigiftaid_Utils_Contribution {
           ->first()['total_amount'];
         $giftAidableContribAmt = self::getGiftAidableContribAmt($totalAmount, $contributionID);
         $giftAidAmount = self::calculateGiftAidAmt($giftAidableContribAmt, self::getBasicRateTax());
-        $lineItemCount = \Civi\Api4\LineItem::get(FALSE)
-          ->selectRowCount()
-          ->addWhere('contribution_id', '=', $contributionID)
-          ->execute()
-          ->count();
-        if ((bccomp($giftAidAmount, 0.0, 1) === 0) && (bccomp($giftAidableContribAmt, 0.0, 1) === 0)
-          && $lineItemCount > 0) {
+        if ((bccomp($giftAidAmount, 0.0, 1) === 0) && (bccomp($giftAidableContribAmt, 0.0, 1) === 0)) {
           // If we don't have an enabled financialType contribution is not eligible
-          $eligibleForGiftAid = 0;
+          $eligibleForGiftAid = NULL;
         }
       }
       $contributionParams[CRM_Civigiftaid_Utils::getCustomByName('eligible_for_gift_aid', 'gift_aid')] = $eligibleForGiftAid;

--- a/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
+++ b/tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php
@@ -956,4 +956,12 @@ class CRM_Civigiftaid_Utils_ContributionTest extends \PHPUnit\Framework\TestCase
     $this->contacts[] = $result;
 
   }
+
+  protected function fetchContributionGiftAid(int $contributionID): array {
+    return Contribution::get(FALSE)
+      ->addWhere('id', '=', $contributionID)
+      ->addSelect('gift_aid.eligible_for_gift_aid', 'gift_aid.amount', 'gift_aid.gift_aid_amount')
+      ->execute()
+      ->first();
+  }
 }


### PR DESCRIPTION
## Overview
This PR fixes an issue which wrongly disabled the giftaid eligibility on contributions which should have giftaid eligibility.

## Technical Details
A scenario in which contribution record is created fist before the creation of line items like webform submission will mark the eligibility as 0 [here](https://lab.civicrm.org/extensions/ukgiftaid/-/blob/master/CRM/Civigiftaid/Utils/Contribution.php?ref_type=heads#L137) because the giftaid amount is calculated based on eligible line items and there are no line items created yet for this contribution and then later on in the same request when the line items gets created [this](https://lab.civicrm.org/extensions/ukgiftaid/-/blob/master/CRM/Civigiftaid/SetContributionGiftAidEligibility.php?ref_type=heads#L101) check does not lets recalculate the eligibility for this contribution.

This PR changes the logic to only set the eligibility as NULL instead of 0 which would result in recalculation of eligibility upon saving of each line item