### PR TITLE
CIVIMM-488: Disable Enabled Financial Types When Global Gift Aid Is On

### DIFF
--- a/js/ukgiftaid.settings.js
+++ b/js/ukgiftaid.settings.js
@@ -1,7 +1,10 @@
 (function($, ts) {
+  var CHECKBOX = 'input#civigiftaid_globally_enabled_civigiftaid_globally_enabled';
+  var SELECT = '#civigiftaid_financial_types_enabled';
+
   function updateFinancialTypesState() {
-    var disabled = $('input#civigiftaid_globally_enabled_civigiftaid_globally_enabled').prop('checked');
-    var $select = $('#civigiftaid_financial_types_enabled');
+    var disabled = $(CHECKBOX).prop('checked');
+    var $select = $(SELECT);
     $select.prop('disabled', disabled);
     // Sync the rendered crm-select2 widget so it greys out, not just the native control.
     var select2 = $.fn.select2;
@@ -15,12 +18,19 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', function() {
+  // Use jQuery ready (idempotent) rather than DOMContentLoaded: CiviCRM injects
+  // this script via addScriptFile, so DOMContentLoaded has usually already fired.
+  $(function() {
     updateFinancialTypesState();
-  });
 
-  $('input#civigiftaid_globally_enabled_civigiftaid_globally_enabled').on('change', function() {
-    updateFinancialTypesState();
+    $(CHECKBOX).on('change', updateFinancialTypesState);
+
+    // A disabled control is not submitted, which would wipe the saved financial
+    // types when the form is saved with the global checkbox ticked. Re-enable it
+    // just before submit so its value is posted.
+    $(SELECT).closest('form').on('submit', function() {
+      $(SELECT).prop('disabled', false);
+    });
   });
 
 }(CRM.$, CRM.ts('uk.co.compucorp.civicrm.giftaid')));

--- a/js/ukgiftaid.settings.js
+++ b/js/ukgiftaid.settings.js
@@ -1,36 +1,23 @@
 (function($, ts) {
-  var CHECKBOX = 'input#civigiftaid_globally_enabled_civigiftaid_globally_enabled';
-  var SELECT = '#civigiftaid_financial_types_enabled';
+  const checkbox = 'input#civigiftaid_globally_enabled_civigiftaid_globally_enabled';
+  const select = '#civigiftaid_financial_types_enabled';
 
-  function updateFinancialTypesState() {
-    var disabled = $(CHECKBOX).prop('checked');
-    var $select = $(SELECT);
-    $select.prop('disabled', disabled);
-    // Sync the rendered crm-select2 widget so it greys out, not just the native control.
-    var select2 = $.fn.select2;
-    if (select2 && select2.amd) {
-      // select2 v4.x reflects the disabled prop on change.
-      $select.trigger('change.select2');
+  function updateFinancialTypesVisibility() {
+    let $select = $(select);
+    let $row = $select.closest('tr');
+
+    if ($(checkbox).prop('checked')) {
+      $select.val(null).trigger('change');
+      $row.hide();
     }
-    else if ($select.data('select2')) {
-      // select2 v3.x.
-      $select.select2('enable', !disabled);
+    else {
+      $row.show();
     }
   }
 
-  // Use jQuery ready (idempotent) rather than DOMContentLoaded: CiviCRM injects
-  // this script via addScriptFile, so DOMContentLoaded has usually already fired.
   $(function() {
-    updateFinancialTypesState();
-
-    $(CHECKBOX).on('change', updateFinancialTypesState);
-
-    // A disabled control is not submitted, which would wipe the saved financial
-    // types when the form is saved with the global checkbox ticked. Re-enable it
-    // just before submit so its value is posted.
-    $(SELECT).closest('form').on('submit', function() {
-      $(SELECT).prop('disabled', false);
-    });
+    updateFinancialTypesVisibility();
+    $(checkbox).on('change', updateFinancialTypesVisibility);
   });
 
 }(CRM.$, CRM.ts('uk.co.compucorp.civicrm.giftaid')));

--- a/js/ukgiftaid.settings.js
+++ b/js/ukgiftaid.settings.js
@@ -1,19 +1,26 @@
 (function($, ts) {
-  function updateVisibleElements() {
-    if ($('input#civigiftaid_globally_enabled_civigiftaid_globally_enabled').prop('checked')) {
-      $('tr.crm--form-block-civigiftaid_financial_types_enabled').hide();
+  function updateFinancialTypesState() {
+    var disabled = $('input#civigiftaid_globally_enabled_civigiftaid_globally_enabled').prop('checked');
+    var $select = $('#civigiftaid_financial_types_enabled');
+    $select.prop('disabled', disabled);
+    // Sync the rendered crm-select2 widget so it greys out, not just the native control.
+    var select2 = $.fn.select2;
+    if (select2 && select2.amd) {
+      // select2 v4.x reflects the disabled prop on change.
+      $select.trigger('change.select2');
     }
-    else {
-      $('tr.crm--form-block-civigiftaid_financial_types_enabled').show();
+    else if ($select.data('select2')) {
+      // select2 v3.x.
+      $select.select2('enable', !disabled);
     }
   }
 
   document.addEventListener('DOMContentLoaded', function() {
-    updateVisibleElements();
+    updateFinancialTypesState();
   });
 
   $('input#civigiftaid_globally_enabled_civigiftaid_globally_enabled').on('change', function() {
-    updateVisibleElements();
+    updateFinancialTypesState();
   });
 
 }(CRM.$, CRM.ts('uk.co.compucorp.civicrm.giftaid')));


### PR DESCRIPTION
## Overview
On the Gift Aid settings page (Administer → CiviContribute → Gift Aid → Settings), when the global **Enable gift aid for line items of any financial type** checkbox is ticked, the per-type **Enabled Financial Types** selection is redundant. Now the row is **cleared and hidden** when the checkbox is ticked. Because the global setting defaults to enabled, the row is hidden on first load.

## Before
With the global checkbox ticked, the dropdown stays fully enabled, editable, and visible. The existing script attempted to hide the row using selector `tr.crm--form-block-civigiftaid_financial_types_enabled`, which does not match the rendered markup (`tr.crm-setting-form-block-...`), so the handler had no effect.

![Before](https://compuco-agents-artifacts-916270379481-eu-west-2-an.s3.eu-west-2.amazonaws.com/CIVIMM-488/20260603-devsite-before.png)

## After
With the global checkbox ticked, the per-type select is **cleared** and its **row hidden**. Unticking shows the (now empty) row again.

![After](https://compuco-agents-artifacts-916270379481-eu-west-2-an.s3.eu-west-2.amazonaws.com/CIVIMM-488/20260603-devsite-after.png)

## Technical Details
`js/ukgiftaid.settings.js` now clears and hides the financial-types row

- On load and on change, when the global checkbox is ticked: clears the `<select>` value (`$select.val(null).trigger('change')`) and hides its containing row.
- The row is resolved via `closest('tr')` rather than a hard-coded class — the previous selector never matched the rendered markup, which is why the original handler was a no-op.
- The `<select>` stays in the DOM (hidden, not disabled), so its cleared value is still submitted; the redundant selection is not persisted. No disable/re-enable-on-submit logic is needed.
- Initialises via jQuery ready instead of `DOMContentLoaded`, since the script is injected with `addScriptFile` after `DOMContentLoaded` has typically already fired.