### PR TITLE
CIVIMM-540: Fix Setting Of Eligibility On Contribution

### DIFF
--- a/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
+++ b/CRM/Civigiftaid/SetContributionGiftAidEligibility.php
@@ -110,6 +110,7 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility extends AutoSubscriber {
         'financial_type_id',
         'contact_id',
         'contribution_recur_id',
+        'total_amount',
         $contributionEligibleGiftAidFieldName,
         $contributionBatchNameFieldName,
         'line_items',
@@ -140,21 +141,29 @@ class CRM_Civigiftaid_SetContributionGiftAidEligibility extends AutoSubscriber {
           $eligibility = 1;
         }
         else {
-          // Assume not eligible until proven eligible.
-          $eligibility = NULL;
-          // We need to look through line items to determine if any of them are eligible.
           if (empty($contribution['line_items'])) {
             // Issue #9: Sometimes line_items are not returned!
-            if (self::financialTypeIsEligible($contribution['financial_type_id'])) {
-              $eligibility = 1;
-            }
+            // The contribution may exist before its line items (e.g. a Webform submission), so if the financial
+            // type is not eligible we leave eligibility NULL ("undetermined") rather than 0, so that it can be
+            // recalculated once line items exist - setting it to 0 would never be recalculated.
+            $eligibility = self::financialTypeIsEligible($contribution['financial_type_id']) ? 1 : NULL;
           }
           else {
+            $eligibility = NULL;
+            $lineItemsTotal = 0;
             foreach ($contribution['line_items'] as $lineItem) {
+              $lineItemsTotal += $lineItem['line_total'] + ($lineItem['tax_amount'] ?? 0);
               if (self::financialTypeIsEligible($lineItem['financial_type_id'])) {
                 $eligibility = 1;
                 break;
               }
+            }
+            if ($eligibility === NULL && ($lineItemsTotal + 0.01) >= (float) $contribution['total_amount']) {
+              // The line items cover the contribution total, so all of them are present and none has an
+              // eligible financial type: definitively not eligible. If they don't yet cover the total
+              // (e.g. a Webform still adding line items one by one) we leave eligibility NULL
+              // ("undetermined") so it is recalculated later - a definitive 0 would never be recalculated.
+              $eligibility = 0;
             }
           }
         }

--- a/CRM/Civigiftaid/Utils/Contribution.php
+++ b/CRM/Civigiftaid/Utils/Contribution.php
@@ -132,8 +132,21 @@ class CRM_Civigiftaid_Utils_Contribution {
         $giftAidableContribAmt = self::getGiftAidableContribAmt($totalAmount, $contributionID);
         $giftAidAmount = self::calculateGiftAidAmt($giftAidableContribAmt, self::getBasicRateTax());
         if ((bccomp($giftAidAmount, 0.0, 1) === 0) && (bccomp($giftAidableContribAmt, 0.0, 1) === 0)) {
-          // If we don't have an enabled financialType contribution is not eligible
-          $eligibleForGiftAid = NULL;
+          $lineItems = CRM_Core_DAO::executeQuery(
+            'SELECT COUNT(*) cnt, COALESCE(SUM(line_total + COALESCE(tax_amount, 0)), 0) total
+             FROM civicrm_line_item WHERE contribution_id = %1',
+            [1 => [$contributionID, 'Int']]
+          );
+          $lineItems->fetch();
+          if (((int) $lineItems->cnt) > 0 && (((float) $lineItems->total) + 0.01) >= (float) $totalAmount) {
+            // The line items cover the contribution total, so all of them are present and none has an
+            // enabled financial type: definitively not eligible.
+            $eligibleForGiftAid = 0;
+          }
+          // Otherwise leave $eligibleForGiftAid as passed in: the contribution's line items may not all exist
+          // yet (e.g. a Webform submission creates them after the contribution), so we keep the eligibility
+          // with zero amounts so that it can be recalculated once all line items exist - a definitive 0
+          // would never be recalculated.
         }
       }
       $contributionParams[CRM_Civigiftaid_Utils::getCustomByName('eligible_for_gift_aid', 'gift_aid')] = $eligibleForGiftAid;


### PR DESCRIPTION
## Overview

Follow-up to the earlier fix for setting Gift Aid eligibility on contributions. That fix stopped contributions from being incorrectly stamped "not eligible" before their line items existed (e.g. Webform submissions), but it went too far: it also stopped the system from ever correcting a contribution back to "not eligible" when it genuinely isn't. This PR makes the two cases behave correctly: eligibility is only left undetermined while line items are still incomplete, and is definitively set (including back to No) once all line items are present.

## Before

- Editing a contribution whose line items are all ineligible no longer reset `eligible_for_gift_aid` to No — a manually (or previously) set "Yes" survived, along with non-zero Gift Aid amounts. Such contributions could end up in a Gift Aid claim batch despite being ineligible.
- `UpdateGiftAidTest::testUpdateFromYesToNo` fails: after setting an Event Fee contribution to eligible=Yes, the expected automatic reset to 0/0/0 never happens (eligibility stays 1, `gift_aid_amount` stays 1).
- `ContributionTest::testEligibleContributionWithoutLineItemsRemainsEligibleUntilLineItemsExist` relied on api3 `CustomValue.create` handling of a `NULL` value — the code wrote `eligible_for_gift_aid = NULL`, so whether the field kept its previous value was ambiguous.

## After

- When a contribution's line items are complete and none has an eligible financial type, eligibility is definitively set to No and the Gift Aid amounts are zeroed — both from the postCommit hook and from `updateGiftAidFields()`.
- When line items are missing or incomplete, eligibility is left `NULL` ("undetermined") so it is recalculated later — a definitive 0 would be sticky and never recalculated (`setGiftAidEligibilityStatus()` returns early for 0 to respect a user's manual "No").
- All tests in `UpdateGiftAidTest` and `ContributionTest` pass, and the two tests above now pass deterministically rather than depending on api3 NULL handling.

## Technical Details

The key question both changed code paths must answer is "do we have enough evidence to make a *definitive* decision?". Line items merely existing is not enough evidence — a Webform can attach them one at a time, so a contribution can transiently have only its ineligible line items (e.g. first line item Event Fee £80 of a £100 contribution, with an eligible £20 Donation still to come). Writing 0 at that moment would be permanent. The completeness signal used is: **the line items (line_total + tax_amount) cover the contribution's total_amount** (with a 1p tolerance, since line totals exclude tax while `total_amount` includes it).

`CRM_Civigiftaid_SetContributionGiftAidEligibility::setGiftAidEligibilityStatus()`:

- No line items returned: eligibility is 1 if the contribution's financial type is eligible, otherwise `NULL` (unchanged behaviour, now explicit).
- Line items present: eligibility is 1 if any line item has an eligible financial type; otherwise 0 **only if** the line items cover `total_amount`, else `NULL`.
- `total_amount` added to the `Order.getsingle` return list to support the completeness check.

`CRM_Civigiftaid_Utils_Contribution::updateGiftAidFields()`:

- When eligibility 1 is passed in but the calculated eligible amount and Gift Aid amount are both 0, the previous code wrote `eligible_for_gift_aid = NULL`. It now queries `civicrm_line_item` for the count and sum: if line items exist and cover `total_amount`, eligibility is written as a definitive 0; otherwise the passed-in eligibility is kept (with zero amounts) so it can be recalculated once the remaining line items exist.
- `NULL` is never written for this field any more, removing the dependency on api3 `CustomValue.create` NULL semantics.

### Core overrides

None.

## Comments

- The failure direction is now safe: any edge case where line items legitimately never sum to `total_amount` results in `NULL` (undetermined, recoverable via the next edit or the `Contribution.UpdateGiftAid` API) rather than a sticky, incorrect Yes or No.
- Verified against the headless suites `tests/phpunit/Api4/Action/Contribution/UpdateGiftAidTest.php` and `tests/phpunit/CRM/Civigiftaid/Utils/ContributionTest.php`.